### PR TITLE
nvdecinfo: print all dimension constraints

### DIFF
--- a/nvdecinfo.c
+++ b/nvdecinfo.c
@@ -156,8 +156,9 @@ static int get_caps(cudaVideoCodec codec_type,
       break;
   }
 
-  printf("%5s | %6s | %5d | %9d | %10d | %15s\n",
-         codec, format, bit_depth, caps.nMaxWidth, caps.nMaxHeight, surface);
+  printf("%5s | %6s | %5d | %9d | %10d | %9d | %10d | %8d | %15s\n",
+         codec, format, bit_depth, caps.nMinWidth, caps.nMinHeight,
+         caps.nMaxWidth, caps.nMaxHeight, caps.nMaxMBCount, surface);
 
   return 0;
 }
@@ -202,11 +203,11 @@ int main(int argc, char *argv[])
     char name[255];
     CHECK_CU(cu->cuDeviceGetName(name, 255, dev));
     printf("Device %d: %s\n", i, name);
-    printf("-----------------------------------------------------------------\n");
+    printf("-----------------------------------------------------------------------------------------------------\n");
 
     CHECK_CU(cu->cuCtxCreate(&cuda_ctx, CU_CTX_SCHED_BLOCKING_SYNC, dev));
-    printf("Codec | Chroma | Depth | Max Width | Max Height | Surface Formats\n");
-    printf("-----------------------------------------------------------------\n");
+    printf("Codec | Chroma | Depth | Min Width | Min Height | Max Width | Max Height |  Max MBs | Surface Formats\n");
+    printf("-----------------------------------------------------------------------------------------------------\n");
     for (int c = 0; c < cudaVideoCodec_NumCodecs; c++) {
       for (int f = 0; f < 4; f++) {
         for (int b = 8; b < 14; b += 2) {
@@ -214,7 +215,7 @@ int main(int argc, char *argv[])
         }
       }
     }
-    printf("-----------------------------------------------------------------\n\n");
+    printf("-----------------------------------------------------------------------------------------------------\n\n");
     cu->cuCtxPopCurrent(&dummy);
   }
 


### PR DESCRIPTION
This information (in particular the maximum number of macroblocks) is relevant for users and cannot be deduced from other values.

Example output:
```
Device 0: NVIDIA GeForce RTX 3050
-----------------------------------------------------------------------------------------------------
Codec | Chroma | Depth | Min Width | Min Height | Max Width | Max Height |  Max MBs | Surface Formats
-----------------------------------------------------------------------------------------------------
MPEG1 |    420 |     8 |        48 |         16 |      4080 |       4080 |    65280 |            NV12
MPEG2 |    420 |     8 |        48 |         16 |      4080 |       4080 |    65280 |            NV12
MPEG4 |    420 |     8 |        48 |         16 |      2032 |       2032 |     8192 |            NV12
  VC1 |    420 |     8 |        48 |         16 |      2032 |       2032 |     8192 |            NV12
 H264 |    420 |     8 |        48 |         16 |      4096 |       4096 |    65536 |            NV12
MJPEG |    400 |     8 |        64 |         64 |     32768 |      16384 | 67108864 |            NV12
MJPEG |    420 |     8 |        64 |         64 |     32768 |      16384 | 67108864 |            NV12
MJPEG |    422 |     8 |        64 |         64 |     32768 |      16384 | 67108864 |            NV12
MJPEG |    444 |     8 |        64 |         64 |     32768 |      16384 | 67108864 |            NV12
 HEVC |    420 |     8 |       144 |        144 |      8192 |       8192 |   262144 |            NV12
 HEVC |    420 |    10 |       144 |        144 |      8192 |       8192 |   262144 |      P016, NV12
 HEVC |    420 |    12 |       144 |        144 |      8192 |       8192 |   262144 |      P016, NV12
 HEVC |    444 |     8 |       144 |        144 |      8192 |       8192 |   262144 |         YUV444P
 HEVC |    444 |    10 |       144 |        144 |      8192 |       8192 |   262144 |       YUV444P16
 HEVC |    444 |    12 |       144 |        144 |      8192 |       8192 |   262144 |       YUV444P16
  VP8 |    420 |     8 |        48 |         16 |      4096 |       4096 |    65536 |            NV12
  VP9 |    420 |     8 |       128 |        128 |      8192 |       8192 |   262144 |            NV12
  VP9 |    420 |    10 |       128 |        128 |      8192 |       8192 |   262144 |      P016, NV12
  VP9 |    420 |    12 |       128 |        128 |      8192 |       8192 |   262144 |      P016, NV12
  AV1 |    400 |     8 |       128 |        128 |      8192 |       8192 |   262144 |            NV12
  AV1 |    400 |    10 |       128 |        128 |      8192 |       8192 |   262144 |            P016
  AV1 |    420 |     8 |       128 |        128 |      8192 |       8192 |   262144 |            NV12
  AV1 |    420 |    10 |       128 |        128 |      8192 |       8192 |   262144 |            P016
-----------------------------------------------------------------------------------------------------
```